### PR TITLE
Fix color for disabled input on dark theme

### DIFF
--- a/src/components/antd/input/s.module.scss
+++ b/src/components/antd/input/s.module.scss
@@ -14,6 +14,7 @@
 }
 
 [data-theme='dark'] .component {
+  --input-bg-disabled: rgb(32, 37, 41);
   --input-border: 1px solid #43484d;
   --input-border-disabled: none;
   --input-text-active: #fff;


### PR DESCRIPTION
Unfortunately I am not able to run the frontend currently because of https://github.com/BarnBridge/barnbridge-frontend/issues/146 but I suspect this should fix the following issue in dark mode:

Currently the disabled inputs are white:
![white](https://user-images.githubusercontent.com/3900799/111221759-32b53300-85db-11eb-98db-2d5eea5e300f.png)

Change to black to match the rest of the theme:
![black](https://user-images.githubusercontent.com/3900799/111221995-86278100-85db-11eb-9b44-fb8b710d55f4.png)
